### PR TITLE
Add bultin validation for strong typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Decorate your function with `@validate_parameters` and define validations to
 each parameter.
 
 ```python
-from parameters_validation import no_whitespaces, non_blank, non_empty, non_negative, validate_parameters
+from parameters_validation import no_whitespaces, non_blank, non_empty, non_negative, strongly_typed, validate_parameters
+
+from  my_app.auth import AuthToken
 
 @validate_parameters
 def register(
+    token: strongly_typed(AuthToken),
     name: non_blank(str),
     age: non_negative(int),
     nickname: no_whitespaces(non_empty(str)),
@@ -22,8 +25,8 @@ def register(
 ```
 
 Then at every function call parameters passed will be validated before actually
-executing it and raise a `ValueError` or do anything else in case of
-custom-defined validations.
+executing it and raise an error or do anything else in case of custom-defined
+validations.
 
 ### Install
 

--- a/parameters_validation/__init__.py
+++ b/parameters_validation/__init__.py
@@ -1,5 +1,5 @@
 from parameters_validation.builtin_validations import non_empty, non_null, \
-    non_blank, no_whitespaces, non_negative
+    non_blank, no_whitespaces, non_negative, strongly_typed
 from parameters_validation.validate_parameters_decorator import validate_parameters
 from parameters_validation.parameter_validation_decorator import parameter_validation
 
@@ -11,4 +11,5 @@ __all__ = [
     non_empty,
     no_whitespaces,
     non_negative,
+    strongly_typed,
 ]

--- a/parameters_validation/builtin_validations.py
+++ b/parameters_validation/builtin_validations.py
@@ -5,6 +5,39 @@ from parameters_validation.parameter_validation_decorator import parameter_valid
 
 
 @parameter_validation
+def strongly_typed(param: object, arg_name: str, arg_type: type):
+    """
+    Validation to reject null, empty or blank strings.
+
+    >>> from parameters_validation import validate_parameters
+    ...
+    ... @validate_parameters
+    ... def foo(bar: strongly_typed(str)):
+    ...     print(bar)
+    ...
+    ... foo("")    # valid: parameter is a string
+    ... foo(None)  # invalid: NoneType does not inherit from string
+    ... foo(1)     # invalid: integer does not inherit from string
+
+    :param param: the parameter's value being validated
+    :param arg_name: the argument name for this parameter (provided by the :meth:`parameter_validation` decorator)
+    :param arg_type: the argument type for this parameter (provided by the :meth:`parameter_validation` decorator)
+    :return: None
+    :raises TypeError: invalid parameter, i.e. :param param: has type that doesn't inherits from the expected :param arg_type:
+    """
+    validation_error = None
+    arg = arg_name
+    try:
+        arg += " <{t}>".format(t=arg_type.__name__)
+        if not isinstance(param, arg_type):
+            validation_error = TypeError("`{arg}` must be of type `{arg_type}`".format(arg=arg, arg_type=arg_type))
+    except:  # TODO: fail at function definition time
+        raise RuntimeError("`strongly_typed` validation must receive the type to enforce")
+    if validation_error:
+        raise validation_error
+
+
+@parameter_validation
 def non_blank(string: str, arg_name: str, arg_type: type = str):
     """
     Validation to reject null, empty or blank strings.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
 
 setup(
     name='parameters-validation',
-    version='1.0.0',
+    version='1.1.0',
     packages=['parameters_validation'],
     url='https://github.com/allrod5/parameters-validation',
     license='MIT',

--- a/test/test_bultin_validations.py
+++ b/test/test_bultin_validations.py
@@ -1,7 +1,7 @@
 import pytest
 
 from parameters_validation import validate_parameters, non_blank, non_null, \
-    non_empty, no_whitespaces, non_negative
+    non_empty, no_whitespaces, non_negative, strongly_typed
 
 
 @validate_parameters
@@ -11,30 +11,44 @@ def foo(
     c: non_empty(),
     d: no_whitespaces(),
     e: non_negative(),
+    f: strongly_typed(str),
 ):
-    return a, b, c, d, e
+    return a, b, c, d, e, f
+
+
+@validate_parameters
+def bar(a: strongly_typed()):
+    return a
 
 
 class TestBuiltinValidations:
     def test_success(self):
-        foo("non-blank", "", [None], "", 42)
+        foo("non-blank", "", [None], "", 42, "")
 
     def test_non_blank(self):
         with pytest.raises(ValueError):
-            foo(" ", "", [None], "", 42)
+            foo(" ", "", [None], "", 42, "")
 
     def test_non_null(self):
         with pytest.raises(ValueError):
-            foo("non-blank", None, [None], "", 42)
+            foo("non-blank", None, [None], "", 42, "")
 
     def test_non_empty(self):
         with pytest.raises(ValueError):
-            foo("non-blank", "", [], "", 42)
+            foo("non-blank", "", [], "", 42, "")
 
     def test_no_whitespaces(self):
         with pytest.raises(ValueError):
-            foo("non-blank", "", [None], "white spaced", 42)
+            foo("non-blank", "", [None], "white spaced", 42, "")
 
     def test_non_negative(self):
         with pytest.raises(ValueError):
-            foo("non-blank", "", [None], "", -42)
+            foo("non-blank", "", [None], "", -42, "")
+
+    def test_strongly_typed(self):
+        with pytest.raises(TypeError):
+            foo("non-blank", "", [None], "", 42, 7)
+
+    def test_strongly_typed_incorrect_usage(self):
+        with pytest.raises(RuntimeError):
+            bar("")


### PR DESCRIPTION
It may be common the need for validating a parameter's type. This PR includes a builtin validation `strongly_typed` to facilitate that.

```python
from parameters_validation import validate_parameters, strongly_typed

@validate_parameters
def foo(bar: strongly_typed(str)):
    print(bar)

foo("")  # Ok
foo(0)  # TypeError
```

`strongly_typed` is different from other validations because receiving the `arg_type` parameter is not optional:

```python
def foo(bar: strongly_typed()):
    pass
```

The above is an invalid usage of `strongly_typed`. This PR is adding this new feature at an **incomplete** state. Currently `foo` will raise a `RuntimeError` when `strongly_typed` is incorrectly used at call time but it should raise an error at the function definition time. This will involve adapting `@parameter_validation` decorator behavior.