### PR TITLE
Fix #5

### DIFF
--- a/parameters_validation/validate_parameters_decorator.py
+++ b/parameters_validation/validate_parameters_decorator.py
@@ -24,15 +24,30 @@ def validate_parameters(func):
     specs = inspect.getfullargspec(func)
     @wraps(func)
     def wrapper(*args, **kwargs):
-        parameters = kwargs.copy()
-        for arg_value, parameter in zip(args, specs.args):
-            parameters[parameter] = arg_value
-
+        parameters = get_parameter_value_dict(args, kwargs)
         for parameter, annotation in specs.annotations.items():
             if not hasattr(annotation, "_parameter_validation"):
                 continue
             annotation(parameters[parameter], parameter)
 
         return func(*args, **kwargs)
+
+    def get_parameter_value_dict(args, kwargs):
+        parameters = kwargs.copy()
+        for arg_value, parameter in zip(args, specs.args):
+            parameters[parameter] = arg_value
+        if specs.defaults:
+            for default_parameter, default_value in zip(specs.args, specs.defaults):
+                if default_parameter in parameters:
+                    pass
+                parameters[default_parameter] = default_value
+        if specs.kwonlydefaults:
+            for default_parameter, default_value in zip(
+                    specs.kwonlyargs, specs.kwonlydefaults
+            ):
+                if default_parameter in parameters:
+                    pass
+                parameters[default_parameter] = default_value
+        return parameters
 
     return wrapper

--- a/tests/bugfixes/test_strongly_typed_on_default_parameters.py
+++ b/tests/bugfixes/test_strongly_typed_on_default_parameters.py
@@ -1,0 +1,26 @@
+"""
+This test covers a fix for a bug first reported in
+https://github.com/allrod5/parameters-validation/issues/5
+
+In version 1.1.1 a function annotated with decorator
+@validate_parameters would crash if the builtin validation
+`strongly_typed` is used for a parameter with default value
+and there is a call to this function that uses the default value
+
+This bug was fixed in version 1.1.2
+"""
+from parameters_validation import non_null, validate_parameters, strongly_typed
+
+
+def test_strongly_typed_on_default_parameters():
+    # given
+    default_value = "default value"
+    @validate_parameters
+    def guinea_pig(a: strongly_typed(str) = default_value):
+        return a
+
+    # when
+    return_value = guinea_pig()
+
+    # then
+    assert return_value == default_value


### PR DESCRIPTION
# What
This PR fixes a bug first reported in #5 

# Why
In version 1.1.1 a function annotated with decorator
@validate_parameters would crash if the builtin validation
`strongly_typed` is used for a parameter with a default value
and there is a call to this function that uses the default value

# How
Decorator `@validate_parameters` wasn't including default parameters' values in the list of parameters to be validated.

**This bugfix will be released in version 1.1.1**