### PR TITLE
Fix Regression of #5

### DIFF
--- a/parameters_validation/validate_parameters_decorator.py
+++ b/parameters_validation/validate_parameters_decorator.py
@@ -37,14 +37,14 @@ def validate_parameters(func):
         for arg_value, parameter in zip(args, specs.args):
             parameters[parameter] = arg_value
         if specs.defaults:
-            for default_parameter, default_value in zip(specs.args, specs.defaults):
+            for default_parameter, default_value in zip(
+                    specs.args[len(specs.args)-len(specs.defaults):], specs.defaults
+            ):
                 if default_parameter in parameters:
                     pass
                 parameters[default_parameter] = default_value
         if specs.kwonlydefaults:
-            for default_parameter, default_value in zip(
-                    specs.kwonlyargs, specs.kwonlydefaults
-            ):
+            for default_parameter, default_value in specs.kwonlydefaults.items():
                 if default_parameter in parameters:
                     pass
                 parameters[default_parameter] = default_value

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
 
 setup(
     name='parameters-validation',
-    version='1.1.2',
+    version='1.1.3',
     packages=['parameters_validation'],
     url='https://github.com/allrod5/parameters-validation',
     license='MIT',

--- a/tests/bugfixes/test_strongly_typed_on_default_parameters.py
+++ b/tests/bugfixes/test_strongly_typed_on_default_parameters.py
@@ -7,20 +7,120 @@ In version 1.1.1 a function annotated with decorator
 `strongly_typed` is used for a parameter with default value
 and there is a call to this function that uses the default value
 
-This bug was fixed in version 1.1.2
+This bug was fixed in version 1.1.3
 """
-from parameters_validation import non_null, validate_parameters, strongly_typed
+from parameters_validation import validate_parameters, strongly_typed
 
 
-def test_strongly_typed_on_default_parameters():
-    # given
-    default_value = "default value"
-    @validate_parameters
-    def guinea_pig(a: strongly_typed(str) = default_value):
-        return a
+class TestStronglyTypedOnDefaultParameters:
+    def test_function_with_just_one_default_arg(self):
+        # given
+        default_value = "default value"
+        @validate_parameters
+        def just_one_default_arg(a: strongly_typed(str) = default_value):
+            return a
 
-    # when
-    return_value = guinea_pig()
+        # when
+        return_value = just_one_default_arg()
 
-    # then
-    assert return_value == default_value
+        # then
+        assert return_value == default_value
+
+    def test_function_with_just_one_default_kwonly_arg(self):
+        # given
+        default_value = "default value"
+        @validate_parameters
+        def just_one_default_kwonly_arg(*, a: strongly_typed(str) = default_value):
+            return a
+
+        # when
+        return_value = just_one_default_kwonly_arg()
+
+        # then
+        assert return_value == default_value
+
+    def test_function_with_default_arg_and_kwonly_arg(self):
+        # given
+        default_value = "default value"
+        @validate_parameters
+        def default_arg_and_kwonly_arg(
+                a: strongly_typed(str) = default_value,
+                b: strongly_typed(str) = default_value,
+        ):
+            return a, b
+
+        # when
+        return_value = default_arg_and_kwonly_arg()
+
+        # then
+        assert return_value == (default_value, default_value)
+
+    def test_function_with_mixed_default_and_not_default_arg_and_kwonly_arg(self):
+        # given
+        default_value = "default value"
+        @validate_parameters
+        def mixed_default_and_not_default_arg_and_kwonly_arg(
+                a: strongly_typed(str),
+                b: strongly_typed(str) = default_value,
+                *,
+                c: strongly_typed(str),
+                d: strongly_typed(str) = default_value
+        ):
+            return a, b, c, d
+
+        # when
+        return_value = mixed_default_and_not_default_arg_and_kwonly_arg(
+            default_value, c=default_value
+        )
+
+        # then
+        assert return_value == (
+            default_value, default_value, default_value, default_value
+        )
+
+    def test_function_with_mixed_default_and_not_default_arg_and_kwonly_arg_2(self):
+        # given
+        default_value = "default value"
+        @validate_parameters
+        def mixed_default_and_not_default_arg_and_kwonly_arg(
+                a: strongly_typed(str),
+                b: strongly_typed(str) = default_value,
+                *,
+                c: strongly_typed(str),
+                d: strongly_typed(str) = default_value
+        ):
+            return a, b, c, d
+
+        # when
+        return_value = mixed_default_and_not_default_arg_and_kwonly_arg(
+            a=default_value, c=default_value
+        )
+
+        # then
+        assert return_value == (
+            default_value, default_value, default_value, default_value
+        )
+
+    def test_function_with_mixed_default_and_not_default_arg_and_kwonly_arg_3(self):
+        # given
+        default_value = "default value"
+        custom_value = "custom value"
+        @validate_parameters
+        def mixed_default_and_not_default_arg_and_kwonly_arg(
+                a: strongly_typed(str),
+                b: strongly_typed(str) = default_value,
+                *,
+                c: strongly_typed(str),
+                d: strongly_typed(str) = default_value
+        ):
+            return a, b, c, d
+
+        # when
+        return_value = mixed_default_and_not_default_arg_and_kwonly_arg(
+            custom_value, custom_value, c=custom_value, d=custom_value
+        )
+
+        # then
+        assert return_value == (
+            custom_value, custom_value, custom_value, custom_value
+        )


### PR DESCRIPTION
# What
This PR fixes a bug first reported in #5 

# Why
In version 1.1.1 a function annotated with decorator
@validate_parameters would crash if the builtin validation
`strongly_typed` is used for a parameter with a default value
and there is a call to this function that uses the default value

# How
Decorator `@validate_parameters` wasn't including default parameters' values in the list of parameters to be validated.

**This bugfix will be released in version 1.1.3**