### PR TITLE
Fix #8

### DIFF
--- a/parameters_validation/validate_parameters_decorator.py
+++ b/parameters_validation/validate_parameters_decorator.py
@@ -41,12 +41,12 @@ def validate_parameters(func):
                     specs.args[len(specs.args)-len(specs.defaults):], specs.defaults
             ):
                 if default_parameter in parameters:
-                    pass
+                    continue
                 parameters[default_parameter] = default_value
         if specs.kwonlydefaults:
             for default_parameter, default_value in specs.kwonlydefaults.items():
                 if default_parameter in parameters:
-                    pass
+                    continue
                 parameters[default_parameter] = default_value
         return parameters
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
 
 setup(
     name='parameters-validation',
-    version='1.1.3',
+    version='1.1.4',
     packages=['parameters_validation'],
     url='https://github.com/allrod5/parameters-validation',
     license='MIT',

--- a/tests/bugfixes/test_validations_on_parameters_with_default_value.py
+++ b/tests/bugfixes/test_validations_on_parameters_with_default_value.py
@@ -1,0 +1,84 @@
+"""
+This test covers a fix for a bug first reported in
+https://github.com/allrod5/parameters-validation/issues/8
+
+In version 1.1.3 validations defined for a parameter with default a
+value are always applied to the default value and not to explicit
+passed values.
+
+This bug was fixed in version 1.1.4
+"""
+import pytest
+
+from parameters_validation import validate_parameters, non_blank, no_whitespaces
+
+
+class TestValidationsOnParameterWithDefaultValue:
+    def test_default_value_success(self):
+        # given
+        default_value = "default_value"
+
+        @validate_parameters
+        def guinea_pig(s: no_whitespaces(non_blank(str)) = default_value):
+            return s
+
+        # when
+        return_value = guinea_pig()
+
+        # then
+        assert return_value == default_value
+
+    def test_bad_default_value(self):
+        # given
+        default_value = "default value"
+
+        @validate_parameters
+        def guinea_pig(s: no_whitespaces(non_blank(str)) = default_value):
+            return s
+
+        # then
+        with pytest.raises(ValueError):
+            guinea_pig()
+
+    def test_custom_value_success(self):
+        # given
+        default_value = "default_value"
+        custom_value = "custom_value"
+
+        @validate_parameters
+        def guinea_pig(s: no_whitespaces(non_blank(str)) = default_value):
+            return s
+
+        # when
+        return_value = guinea_pig(custom_value)
+
+        # then
+        assert return_value == custom_value
+
+    def test_bad_custom_value(self):
+        # given
+        default_value = "default_value"
+        whitespaced_string = "whitespaced string"
+        blank_string = "    "
+        empty_string = ""
+        null_string = None
+
+        @validate_parameters
+        def guinea_pig(s: no_whitespaces(non_blank(str)) = default_value):
+            return s
+
+        # then
+        with pytest.raises(ValueError):
+            guinea_pig(whitespaced_string)
+
+        # then
+        with pytest.raises(ValueError):
+            guinea_pig(blank_string)
+
+        # then
+        with pytest.raises(ValueError):
+            guinea_pig(empty_string)
+
+        # then
+        with pytest.raises(ValueError):
+            guinea_pig(null_string)


### PR DESCRIPTION
# What
This PR fixes a bug first reported in #8

# Why
In version 1.1.3 validations defined for a parameter with default a
value are always applied to the default value and not to the explicit
passed values.

# How
Decorator `@validate_parameters` was overwriting the explicitly passed values with the parameter's default value.

**This bugfix will be released in version 1.1.4**